### PR TITLE
Update the wrapper to utilise `/resolc` endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22-bookworm-slim
 
 ENV SOLC_VERSION="0.8.26"
-ENV RESOLC_VERSION="0.0.1"
+ENV RESOLC_VERSION="0.1.0-dev"
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
@@ -15,7 +15,7 @@ RUN wget --progress=dot:mega https://github.com/ethereum/solidity/releases/downl
     -O /usr/local/bin/solc && chmod +x /usr/local/bin/solc
 
 # Download and install re-solc
-RUN wget --progress=dot:mega https://github.com/smiasojed/revive/releases/download/${RESOLC_VERSION}/resolc \
+RUN wget --progress=dot:mega https://github.com/paritytech/revive/releases/download/v${RESOLC_VERSION}/resolc \
     -O /usr/local/bin/resolc && chmod +x /usr/local/bin/resolc
 
 RUN chown node:node /usr/local/bin/resolc /usr/local/bin/solc

--- a/controllers/metricsController.js
+++ b/controllers/metricsController.js
@@ -24,7 +24,7 @@ const getMetrics = async (req, res) => {
   } catch (ex) {
     log('error', 'Failed to get metrics', {
       method: req.method,
-      endpoint: req.path,
+      endpoint: req.originalUrl,
       error: ex.message,
     });
     res.status(500).end(ex.message);

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -8,7 +8,7 @@ const processTask = (binName) => (req, res) => {
   const end = httpRequestDuration.startTimer();
   log('info', 'Received request', {
     method: req.method,
-    endpoint: req.path,
+    endpoint: req.originalUrl,
     command: req.body.cmd || 'unknown',
   });
 

--- a/middleware/reposnseHandler.js
+++ b/middleware/reposnseHandler.js
@@ -16,18 +16,18 @@ function getErrorMessage(statusCode) {
 function handleError(request, response, end, status, error = null) {
   httpRequestCount.inc({
     method: request.method,
-    endpoint: request.path,
+    endpoint: request.originalUrl,
     status,
   });
   httpRequestErrors.inc({
     method: request.method,
-    endpoint: request.path,
+    endpoint: request.originalUrl,
     status,
   });
 
   log('error', 'Request processing failed', {
     method: request.method,
-    endpoint: request.path,
+    endpoint: request.originalUrl,
     command: request.body.cmd || 'unknown',
     status,
     error: error || getErrorMessage(status),
@@ -39,12 +39,12 @@ function handleError(request, response, end, status, error = null) {
     // Log the sending failure
     log('error', 'Failed to send error response', {
       method: request.method,
-      endpoint: request.path,
+      endpoint: request.originalUrl,
       status,
       error: sendError.message,
     });
   } finally {
-    end({ method: request.method, endpoint: request.path, status });
+    end({ method: request.method, endpoint: request.originalUrl, status });
   }
 }
 
@@ -52,12 +52,12 @@ function handleResult(request, response, end, result) {
   const status = 200;
   httpRequestCount.inc({
     method: request.method,
-    endpoint: request.path,
+    endpoint: request.originalUrl,
     status,
   });
   log('info', 'Request processed successfully', {
     method: request.method,
-    endpoint: request.path,
+    endpoint: request.originalUrl,
     command: request.body.cmd,
     status,
   });
@@ -68,17 +68,17 @@ function handleResult(request, response, end, result) {
     // Log the sending failure
     log('error', 'Failed to send error response', {
       method: request.method,
-      endpoint: request.path,
+      endpoint: request.originalUrl,
       status,
       error: sendError.message,
     });
     httpRequestErrors.inc({
       method: request.method,
-      endpoint: request.path,
+      endpoint: request.originalUrl,
       status,
     });
   } finally {
-    end({ method: request.method, endpoint: request.path, status });
+    end({ method: request.method, endpoint: request.originalUrl, status });
   }
 }
 

--- a/public/soljson.js
+++ b/public/soljson.js
@@ -1,12 +1,14 @@
 //! This is the compiler worker executed byt Remix IDE
 //! It proxies requests to the solc proxy server
 let missingSources = [];
-let compilerBackend = 'http://localhost:3000/resolc';
+// Staging backend
+//let compilerBackend='https://remix-backend.parity-stg.parity.io'
+let compilerBackend = 'http://localhost:3000';
 
 // synchronous fetch
-function proxySync(cmd, input) {
+function proxySync(path, cmd, input) {
   const request = new XMLHttpRequest();
-  request.open('POST', compilerBackend, false);
+  request.open('POST', compilerBackend + path, false);
   request.setRequestHeader('Content-Type', 'application/json');
   request.send(JSON.stringify({ cmd, input }));
   if (request.status === 200) {
@@ -19,8 +21,9 @@ function proxySync(cmd, input) {
 }
 
 // asynchronous fetch
-async function proxyAsync(cmd, input) {
-  const resp = await fetch(compilerBackend, {
+async function proxyAsync(path, cmd, input) {
+  console.log('fetching ' + compilerBackend + path);
+  const resp = await fetch(compilerBackend + path, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -40,7 +43,7 @@ self.onmessage = async function (e) {
   console.log('soljson.js received message', e.data);
   try {
     if (e.data.cmd === 'compile') {
-      let result = await proxyAsync('--standard-json', e.data.input);
+      let result = await proxyAsync('/resolc', '--standard-json', e.data.input);
       let data = JSON.parse(result);
       if (data.errors) {
         data.errors.forEach((err) => {
@@ -113,12 +116,12 @@ function cwrap(methodName) {
 }
 
 function _solidity_license() {
-  const stdout = proxySync('--license', '');
+  const stdout = proxySync('/resolc', '--license');
   return stdout;
 }
 
 function _solidity_version() {
-  const stdout = proxySync('--version', '');
+  const stdout = proxySync('/solc', '--version');
   const versionMatch = stdout.match(/[v\s]([\d.]+)/);
   return versionMatch[1];
 }

--- a/public/soljson.js
+++ b/public/soljson.js
@@ -2,7 +2,7 @@
 //! It proxies requests to the solc proxy server
 let missingSources = [];
 // Staging backend
-//let compilerBackend='https://remix-backend.parity-stg.parity.io'
+// let compilerBackend='https://remix-backend.parity-stg.parity.io/solc'
 let compilerBackend = 'http://localhost:3000';
 
 // synchronous fetch
@@ -22,7 +22,6 @@ function proxySync(path, cmd, input) {
 
 // asynchronous fetch
 async function proxyAsync(path, cmd, input) {
-  console.log('fetching ' + compilerBackend + path);
   const resp = await fetch(compilerBackend + path, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Update the `soljson.js` wrapper
Fix reported endpoint in logs and metrics
Use the official revive release